### PR TITLE
Transaction Scope Control

### DIFF
--- a/source/NHibernate.AspNet.Identity/RoleStore`1.cs
+++ b/source/NHibernate.AspNet.Identity/RoleStore`1.cs
@@ -45,7 +45,6 @@ namespace NHibernate.AspNet.Identity
             if ((object)role == null)
                 throw new ArgumentNullException("role");
             Context.Save(role);
-            Context.Flush();
             return Task.FromResult(0);
         }
 
@@ -57,7 +56,6 @@ namespace NHibernate.AspNet.Identity
                 throw new ArgumentNullException("role");
             }
             Context.Delete(role);
-            Context.Flush();
             return Task.FromResult(0);
         }
 
@@ -67,7 +65,6 @@ namespace NHibernate.AspNet.Identity
             if ((object)role == null)
                 throw new ArgumentNullException("role");
             Context.Update(role);
-            Context.Flush();
             return Task.FromResult(0);
         }
 

--- a/source/NHibernate.AspNet.Identity/UserStore`1.cs
+++ b/source/NHibernate.AspNet.Identity/UserStore`1.cs
@@ -33,7 +33,7 @@ namespace NHibernate.AspNet.Identity
                 throw new ArgumentNullException("context");
             }
 
-            this.ShouldDisposeSession = true;
+            this.ShouldDisposeSession = false;
             this.Context = context;
         }
 
@@ -60,7 +60,6 @@ namespace NHibernate.AspNet.Identity
             }
 
             Context.Save(user);
-            Context.Flush();
 
             return Task.FromResult(0);
         }
@@ -73,7 +72,6 @@ namespace NHibernate.AspNet.Identity
             }
 
             this.Context.Delete(user);
-            Context.Flush();
 
             return Task.FromResult(0);
         }
@@ -87,7 +85,6 @@ namespace NHibernate.AspNet.Identity
             }
 
             this.Context.Update(user);
-            Context.Flush();
 
             return Task.FromResult(0);
         }

--- a/source/NHibernate.AspNet.Web/Startup.cs
+++ b/source/NHibernate.AspNet.Web/Startup.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Owin;
+using NHibernate.AspNet.Identity;
 using Owin;
+using SharpArch.NHibernate;
 using SharpArch.NHibernate.Web.Mvc;
 
 [assembly: OwinStartupAttribute(typeof(NHibernate.AspNet.Web.Startup))]
@@ -17,6 +19,13 @@ namespace NHibernate.AspNet.Web
         {
             var storage = new WebSessionStorage(System.Web.HttpContext.Current.ApplicationInstance);
             DataConfig.Configure(storage);
+
+            using (var transaction = NHibernateSession.Current.BeginTransaction())
+            {
+                NHibernateSession.Current.Persist(new IdentityRole("Users"));
+               
+                transaction.Commit();
+            }
         }
     }
 }


### PR DESCRIPTION
Hi Antonio

In this PR I have removed Session.Flush calls from the stores.  This enables application code to control transaction scope and thus perform atomic composite operations such as create user and add to role, see the Account controller registration method and also where I have add transaction code to the tests.

The application that I am currently working on requires this. If a user were created but the subsequent call to add the relevant role failed we would be left with a user account unable to login but preventing the registration from being re-completed.

I haven't been able to run the specs locally (it's probably something environmental) so I can't confirm that this  PR is completely good to go but I thought you might be interested in seeing it.

Thanks
Myles (mcdonnell.myles@gmail.com)